### PR TITLE
Fix asciibinder dockerfile

### DIFF
--- a/asciibinder/Dockerfile
+++ b/asciibinder/Dockerfile
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi8/ruby-27
 
+ENV LANG=en_US.UTF-8
+
 USER root
-RUN gem install listen -v 3.0.8
-RUN gem install ascii_binder
-RUN asciibinder --version
-RUN yum clean all
+
+RUN gem install listen:3.0.8 ascii_binder && \
+    yum clean all
 
 LABEL url="http://www.asciibinder.org" \
       summary="a documentation system built on Asciidoctor" \
@@ -13,5 +14,4 @@ LABEL url="http://www.asciibinder.org" \
           -v `pwd`:/docs:z \
           IMAGE"
 
-ENV LANG=en_US.UTF-8
 WORKDIR /docs

--- a/asciibinder/Dockerfile
+++ b/asciibinder/Dockerfile
@@ -1,19 +1,17 @@
-FROM centos/ruby-23-centos7
+FROM registry.access.redhat.com/ubi8/ruby-27
 
-RUN scl enable rh-ruby23 -- gem install listen -v 3.0.8
-RUN scl enable rh-ruby23 -- gem install ascii_binder
 USER root
-RUN yum install -y java-1.7.0-openjdk && \
-    yum clean all
+RUN gem install listen -v 3.0.8
+RUN gem install ascii_binder
+RUN asciibinder --version
+RUN yum clean all
 
 LABEL url="http://www.asciibinder.org" \
       summary="a documentation system built on Asciidoctor" \
-      description="AsciiBinder is for documenting versioned, interrelated projects. Run this container image from the documentation repository, which is mounted into the container. Note: Generated files will be owned by root." \
+      description="Run the asciibinder container image from the local docs repo, which is mounted into the container. Pass asciibinder commands to run the build. Generated files are owned by root." \
       RUN="docker run -it --rm \
           -v `pwd`:/docs:z \
           IMAGE"
 
-ENV JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.95-2.6.4.0.el7_2.x86_64/jre/
 ENV LANG=en_US.UTF-8
 WORKDIR /docs
-CMD asciibinder package

--- a/asciibinder/README.md
+++ b/asciibinder/README.md
@@ -5,11 +5,11 @@ installing asciibinder directly. To build your local asciidoc content, run one o
 following commands from the asciidoc source folder:
 
 ```
-podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/docs-builder/asciibinder asciibinder build
+podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/asciibinder asciibinder build
 ```
 
 To build a specific distro, for example, `openshift-enterprise` run:
 
 ```
-podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/docs-builder/asciibinder asciibinder build -d openshift-enterprise
+podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/asciibinder asciibinder build -d openshift-enterprise
 ```

--- a/asciibinder/README.md
+++ b/asciibinder/README.md
@@ -1,9 +1,15 @@
 # Running the asciibinder container build locally
 
 You can use the asciibinder container to build local asciidoc content without
-installing asciibinder directly. To build your local asciidoc content, run the
-following command from the asciidoc source folder:
+installing asciibinder directly. To build your local asciidoc content, run one of the
+following commands from the asciidoc source folder:
 
 ```
 podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/docs-builder/asciibinder asciibinder build
+```
+
+To build a specific distro, for example, `openshift-enterprise` run:
+
+```
+podman run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/docs-builder/asciibinder asciibinder build -d openshift-enterprise
 ```


### PR DESCRIPTION
Changes:
* Built from registry.access.redhat.com/ubi8/ruby-27
* Upgraded asciibinder to 1.0.1
* Upgraded to ruby27
* Move asciibinder build commands out of container